### PR TITLE
Fix long usernames making the link difficult to see.

### DIFF
--- a/static/style.less
+++ b/static/style.less
@@ -161,6 +161,7 @@ footer {
         text-align: center;
         img {
             margin-bottom: -.5em;
+            border: none;
         }
         font-weight: 200;
     }

--- a/static/style.less
+++ b/static/style.less
@@ -30,7 +30,7 @@ header {
     position: fixed;
     top: 0;
     left: 0;
-    height: 50px;
+    min-height: 50px;
     width: 100%;
     border-bottom: 2px solid rgba(15, 38, 61, 0.5);
     -moz-box-shadow: 0 1px 8px rgba(0, 0, 0, 0.6);
@@ -63,11 +63,12 @@ header {
 
     .picture {
         float: left;
-        margin: 10px;
+        margin: 10px 10px 0 0;
     }
     .login {
         float: left;
         margin-top: 10px;
+        max-width: 208px;
         img {
             margin-top: 3px;
         }


### PR DESCRIPTION
- Fix the width of the login box.
- Give slightly more space to the username by reducing the margin on the left side of the photo.
- set the min-height instead of the height of the header so that when usernames do take up multiple lines, the header accommodates.
- Adding border: none around the BrowserID logo in the footer. 

BrowserID issue 985
https://github.com/mozilla/browserid/issues/985
