### PR TITLE
Fix for the 'login failure [object Object]' being displayed when there is an XHR failure.

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -122,8 +122,8 @@ function gotVerifiedEmail(assertion) {
         if (res === null) loggedOut();
         else loggedIn(res);
       },
-      error: function(res, status, xhr) {
-        alert("login failure" + res);
+      error: function(xhr, status, error) {
+        alert("login failure " + error);
       }
     });
   }
@@ -143,7 +143,7 @@ if (document.addEventListener) {
 }
 
 $('#installApp button').click(function() {
-  navigator.mozApps.install("/myfavoritebeer.webapp", "receipt goes here", 
+  navigator.mozApps.install("/myfavoritebeer.webapp", "receipt goes here",
     function success() {
       console.log('Install success');
     }, function error() {


### PR DESCRIPTION
The order of the arguments for the error handler are different than the success handler.  Changed the ordering, print out the error.

BrowserID #567
