### PR TITLE
Change link to My FavouriteSandwich to be http

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ should run under the hosting environment of your preference.
 
 ## Credit
 
-Concept + Design(kinda): https://myfavouritesandwich.org/
+Concept + Design(kinda): http://myfavouritesandwich.org/
 Art:                     http://www.flickr.com/photos/bitzi/236037776/

--- a/static/index.html
+++ b/static/index.html
@@ -66,7 +66,7 @@
 
         <small>
           (Thanks to <a href="http://www.flickr.com/photos/samsmith/252630747">@samsmith for the photo</a>,
-          and the <a href="https://myfavouritesandwich.org">unhosted dudes for the concept</a>)
+          and the <a href="http://myfavouritesandwich.org">unhosted dudes for the concept</a>)
         </small>
 
       </div>


### PR DESCRIPTION
We want to move our demo app to be a client-side app, and have it hosted on a http-only service. We would be grateful if you could update the link here as well!

Cheers,
Michiel.
